### PR TITLE
Update version to 2.1.3 in package.json and adjust VersionBadge positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "object-synth",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/editor/components/VersionBadge.tsx
+++ b/src/editor/components/VersionBadge.tsx
@@ -2,7 +2,7 @@ import { appVersionInfo } from '../../version';
 
 export const VersionBadge = () => {
   return (
-    <aside className="fixed bottom-2 right-2 rounded-box border border-base-300 bg-base-100/90 px-2.5 py-1.5 text-[11px] text-base-content shadow-lg backdrop-blur md:bottom-3 md:right-3 md:px-3 md:py-2 md:text-xs">
+    <aside className="fixed bottom-2 left-2 rounded-box border border-base-300 bg-base-100/90 px-2.5 py-1.5 text-[11px] text-base-content shadow-lg backdrop-blur md:bottom-3 md:left-3 md:px-3 md:py-2 md:text-xs">
       <div className="font-medium">
         <span className="text-primary">v</span>
         {appVersionInfo.version}


### PR DESCRIPTION
- Bump version number in package.json to 2.1.3.
- Change the position of the VersionBadge component from the bottom-right to the bottom-left of the screen for improved visibility.